### PR TITLE
Align data and `brms` output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Description: The mixed model for repeated measures (MMRM) is a
   and align with best practices for the life sciences.
   References: Bürkner (2017) <10.18637/jss.v080.i01>,
   Mallinckrodt (2008) <doi:10.1177/009286150804200402>.
-Version: 0.0.0.9001
+Version: 0.0.0.9002
 License: MIT + file LICENSE
 URL: https://github.com/RConsortium/brms.mmrm
 BugReports: https://github.com/RConsortium/brms.mmrm/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,3 @@
-# brms.mmrm 0.0.0.9001
-
-* Encapsulate data with roles as attributes (#31).
-
-# brms.mmrm 0.0.0.9000
+# brms.mmrm 0.0.0.9002 (development)
 
 * First version.

--- a/R/brm_data.R
+++ b/R/brm_data.R
@@ -75,13 +75,6 @@ brm_data <- function(
   brm_data_preprocess(out)
 }
 
-brm_data_preprocess <- function(out) {
-  out <- brm_data_level(out)
-  out <- brm_data_fill(out)
-  out <- brm_data_select(out)
-  out
-}
-
 brm_data_new <- function(
   data,
   outcome,
@@ -107,6 +100,13 @@ brm_data_new <- function(
     levels_group = levels_group,
     levels_time = levels_time
   )
+}
+
+brm_data_preprocess <- function(out) {
+  out <- brm_data_level(out)
+  out <- brm_data_fill(out)
+  out <- brm_data_select(out)
+  out
 }
 
 brm_data_validate <- function(data) {

--- a/R/brm_data.R
+++ b/R/brm_data.R
@@ -72,6 +72,10 @@ brm_data <- function(
     levels_time = NULL
   )
   brm_data_validate(data = out)
+  brm_data_preprocess(out)
+}
+
+brm_data_preprocess <- function(out) {
   out <- brm_data_level(out)
   out <- brm_data_fill(out)
   out <- brm_data_select(out)

--- a/R/brm_formula.R
+++ b/R/brm_formula.R
@@ -22,7 +22,7 @@
 #' @examples
 #' set.seed(0)
 #' data <- brm_data(
-#'   data = tibble::as_tibble(brm_simulate()$data),
+#'   data = brm_simulate()$data,
 #'   outcome = "response",
 #'   role = "response",
 #'   group = "group",
@@ -66,13 +66,13 @@ brm_formula <- function(
       paste(correlations, collapse = ", ")
     )
   )
-  outcome <- attr(data, "outcome")
-  role <- attr(data, "role")
-  base <- attr(data, "base")
-  group <- attr(data, "group")
-  time <- attr(data, "time")
-  patient <- attr(data, "patient")
-  covariates <- attr(data, "covariates")
+  outcome <- attr(data, "brm_outcome")
+  role <- attr(data, "brm_role")
+  base <- attr(data, "brm_base")
+  group <- attr(data, "brm_group")
+  time <- attr(data, "brm_time")
+  patient <- attr(data, "brm_patient")
+  covariates <- attr(data, "brm_covariates")
   terms <- c(
     term("0", !intercept),
     term(time, effect_time),

--- a/R/brm_marginal_data.R
+++ b/R/brm_marginal_data.R
@@ -26,25 +26,23 @@
 #'   intervals.
 #' @examples
 #' set.seed(0L)
-#'  data <- brm_data(
-#'    data = tibble::as_tibble(brm_simulate()$data),
-#'    outcome = "response",
-#'    role = "response",
-#'    group = "group",
-#'    time = "time",
-#'    patient = "patient"
-#'  )
-#' data$group <- paste("treatment", data$group)
-#' data$time <- paste("visit", data$time)
+#' data <- brm_data(
+#'   data = brm_simulate()$data,
+#'   outcome = "response",
+#'   role = "response",
+#'   group = "group",
+#'   time = "time",
+#'   patient = "patient"
+#' )
 #' brm_marginal_data(data = data)
 brm_marginal_data <- function(data, level = 0.95) {
   brm_data_validate(data)
   assert(level, . >= 0, . <= 1, message = "level arg must be between 0 and 1")
   z <- stats::qnorm(p = (1 - level) / 2)
   data <- tibble::tibble(
-    outcome = data[[attr(data, "outcome")]],
-    group = data[[attr(data, "group")]],
-    time = data[[attr(data, "time")]]
+    outcome = data[[attr(data, "brm_outcome")]],
+    group = data[[attr(data, "brm_group")]],
+    time = data[[attr(data, "brm_time")]]
   )
   data <- dplyr::group_by(data, group, time)
   out <- dplyr::summarize(

--- a/R/brm_marginal_draws.R
+++ b/R/brm_marginal_draws.R
@@ -61,8 +61,8 @@
 #' brm_marginal_draws(
 #'   model = model,
 #'   data = data,
-#'   control = "group.1",
-#'   baseline = "time.1"
+#'   control = "group 1",
+#'   baseline = "time 1"
 #' )
 #' }
 brm_marginal_draws <- function(
@@ -72,14 +72,14 @@ brm_marginal_draws <- function(
   baseline = "Baseline"
 ) {
   brm_data_validate(data)
-  role <- attr(data, "role")
-  base <- attr(data, "base")
-  group <- attr(data, "group")
-  time <- attr(data, "time")
-  patient <- attr(data, "patient")
-  covariates <- attr(data, "covariates")
-  levels_group <- attr(data, "levels_group")
-  levels_time <- attr(data, "levels_time")
+  role <- attr(data, "brm_role")
+  base <- attr(data, "brm_base")
+  group <- attr(data, "brm_group")
+  time <- attr(data, "brm_time")
+  patient <- attr(data, "brm_patient")
+  covariates <- attr(data, "brm_covariates")
+  levels_group <- attr(data, "brm_levels_group")
+  levels_time <- attr(data, "brm_levels_time")
   assert(
     control,
     is.atomic(.),
@@ -94,8 +94,8 @@ brm_marginal_draws <- function(
     !anyNA(.),
     message = "baseline arg must be a length-1 non-missing atomic value"
   )
-  control <- brm_data_sanitize_level(control)
-  baseline <- brm_data_sanitize_level(baseline)
+  control <- brm_names(control)
+  baseline <- brm_names(baseline)
   assert(
     control %in% as.character(data[[group]]),
     message = "control arg must be a treatment group level in the data"
@@ -187,9 +187,3 @@ subtract_control <- function(draws, levels_group, levels_time, control) {
   }
   out
 }
-
-name_marginal <- function(group, time) {
-  sprintf("%s%s%s", group, brm_sep(), time)
-}
-
-names_mcmc <- c(".chain", ".draw", ".iteration")

--- a/R/brm_marginal_draws.R
+++ b/R/brm_marginal_draws.R
@@ -20,13 +20,13 @@
 #' @param data Classed tibble with preprocessed data from [brm_data()].
 #' @param control Element of the `group` column in the data which indicates
 #'   the control group for the purposes of calculating treatment differences.
-#'   Elements in `data[[group]]` are already pre-processed by [brms_data()],
+#'   Elements in `data[[group]]` are already pre-processed by [brm_data()],
 #'   so `control` is automatically sanitized accordingly using
 #'   `make.names(control, unique = FALSE, allow_ = TRUE)`.
 #' @param baseline Element of the `time` column in the data
 #'   which indicates the baseline time for the purposes of calculating
 #'   change from baseline.
-#'   Elements in `data[[group]]` are already pre-processed by [brms_data()],
+#'   Elements in `data[[group]]` are already pre-processed by [brm_data()],
 #'   so `control` is automatically sanitized accordingly using
 #'   `make.names(control, unique = FALSE, allow_ = TRUE)`.
 #' @examples

--- a/R/brm_marginal_probabilities.R
+++ b/R/brm_marginal_probabilities.R
@@ -28,15 +28,13 @@
 #' if (identical(Sys.getenv("BRM_EXAMPLES", unset = ""), "true")) {
 #' set.seed(0L)
 #' data <- brm_data(
-#'   data = tibble::as_tibble(brm_simulate()$data),
+#'   data = brm_simulate()$data,
 #'   outcome = "response",
 #'   role = "response",
 #'   group = "group",
 #'   time = "time",
 #'   patient = "patient"
 #' )
-#' data$group <- paste("treatment", data$group)
-#' data$time <- paste("visit", data$time)
 #' formula <- brm_formula(
 #'   data = data,
 #'   effect_base = FALSE,
@@ -58,8 +56,8 @@
 #' draws <- brm_marginal_draws(
 #'   model = model,
 #'   data = data,
-#'   control = "treatment 1",
-#'   baseline = "visit 1"
+#'   control = "group 1",
+#'   baseline = "time 1"
 #' )
 #' brm_marginal_probabilities(draws, direction = "greater", threshold = 0)
 #' }

--- a/R/brm_marginal_summaries.R
+++ b/R/brm_marginal_summaries.R
@@ -33,15 +33,13 @@
 #' if (identical(Sys.getenv("BRM_EXAMPLES", unset = ""), "true")) {
 #' set.seed(0L)
 #' data <- brm_data(
-#'   data = tibble::as_tibble(brm_simulate()$data),
+#'   data = brm_simulate()$data,
 #'   outcome = "response",
 #'   role = "response",
 #'   group = "group",
 #'   time = "time",
 #'   patient = "patient"
 #' )
-#' data$group <- paste("treatment", data$group)
-#' data$time <- paste("visit", data$time)
 #' formula <- brm_formula(
 #'   data = data,
 #'   effect_base = FALSE,
@@ -63,8 +61,8 @@
 #' draws <- brm_marginal_draws(
 #'   model = model,
 #'   data = data,
-#'   control = "treatment 1",
-#'   baseline = "visit 1"
+#'   control = "group 1",
+#'   baseline = "time 1"
 #' )
 #' suppressWarnings(brm_marginal_summaries(draws))
 #' }

--- a/R/brm_model.R
+++ b/R/brm_model.R
@@ -17,7 +17,7 @@
 #' if (identical(Sys.getenv("BRM_EXAMPLES", unset = ""), "true")) {
 #' set.seed(0L)
 #' data <- brm_data(
-#'   data = tibble::as_tibble(brm_simulate()$data),
+#'   data = brm_simulate()$data,
 #'   outcome = "response",
 #'   role = "response",
 #'   group = "group",

--- a/R/brm_package.R
+++ b/R/brm_package.R
@@ -54,7 +54,8 @@ globalVariables(
     "group",
     "time",
     "value",
-    "outcome"
+    "outcome",
+    "level"
   ),
   package = "brms.mmrm"
 )

--- a/R/brm_plot_compare.R
+++ b/R/brm_plot_compare.R
@@ -13,15 +13,13 @@
 #' if (identical(Sys.getenv("BRM_EXAMPLES", unset = ""), "true")) {
 #' set.seed(0L)
 #' data <- brm_data(
-#'   data = tibble::as_tibble(brm_simulate()$data),
+#'   data = brm_simulate()$data,
 #'   outcome = "response",
 #'   role = "response",
 #'   group = "group",
 #'   time = "time",
 #'   patient = "patient"
 #' )
-#' data$group <- paste("treatment", data$group)
-#' data$time <- paste("visit", data$time)
 #' formula <- brm_formula(
 #'   data = data,
 #'   effect_base = FALSE,
@@ -43,8 +41,8 @@
 #' draws <- brm_marginal_draws(
 #'   model = model,
 #'   data = data,
-#'   control = "treatment 1",
-#'   baseline = "visit 1"
+#'   control = "group 1",
+#'   baseline = "time 1"
 #' )
 #' suppressWarnings(summaries_draws <- brm_marginal_summaries(draws))
 #' summaries_data <- brm_marginal_data(data)

--- a/R/brm_plot_draws.R
+++ b/R/brm_plot_draws.R
@@ -9,15 +9,13 @@
 #' if (identical(Sys.getenv("BRM_EXAMPLES", unset = ""), "true")) {
 #' set.seed(0L)
 #' data <- brm_data(
-#'   data = tibble::as_tibble(brm_simulate()$data),
+#'   data = brm_simulate()$data,
 #'   outcome = "response",
 #'   role = "response",
 #'   group = "group",
 #'   time = "time",
 #'   patient = "patient"
 #' )
-#' data$group <- paste("treatment", data$group)
-#' data$time <- paste("visit", data$time)
 #' formula <- brm_formula(
 #'   data = data,
 #'   effect_base = FALSE,
@@ -39,8 +37,8 @@
 #' draws <- brm_marginal_draws(
 #'   model = model,
 #'   data = data,
-#'   control = "treatment 1",
-#'   baseline = "visit 1"
+#'   control = "group 1",
+#'   baseline = "time 1"
 #' )
 #' brm_plot_draws(draws = draws$change)
 #' }

--- a/R/brm_simulate.R
+++ b/R/brm_simulate.R
@@ -55,7 +55,6 @@ brm_simulate <- function(
   )
   levels_time <- paste("time", seq_len(n_time))
   grid <- tidyr::expand_grid(patients, time = levels_time)
-  grid$time <- ordered(grid$time, levels = levels_time)
   model_matrix <- model.matrix(~ 0 + group + time, data = grid)
   beta <- stats::rnorm(n = ncol(model_matrix), mean = 0, sd = hyper_beta)
   mean <- as.numeric(model_matrix %*% beta)

--- a/R/brm_simulate.R
+++ b/R/brm_simulate.R
@@ -50,10 +50,12 @@ brm_simulate <- function(
     message = "hyper_correlation must be 1 positive number"
   )
   patients <- tibble::tibble(
-    group = factor(rep(seq_len(n_group), each = n_patient)),
-    patient = factor(seq_len(n_group * n_patient))
+    group = paste("group", rep(seq_len(n_group), each = n_patient)),
+    patient = paste("patient", seq_len(n_group * n_patient))
   )
-  grid <- tidyr::expand_grid(patients, time = factor(seq_len(n_time)))
+  levels_time <- paste("time", seq_len(n_time))
+  grid <- tidyr::expand_grid(patients, time = levels_time)
+  grid$time <- ordered(grid$time, levels = levels_time)
   model_matrix <- model.matrix(~ 0 + group + time, data = grid)
   beta <- stats::rnorm(n = ncol(model_matrix), mean = 0, sd = hyper_beta)
   mean <- as.numeric(model_matrix %*% beta)

--- a/R/utils_assert.R
+++ b/R/utils_assert.R
@@ -54,7 +54,7 @@ assert_lgl <- function(value, message = NULL) {
 
 assert_machine_names <- function(value, message = NULL) {
   name <- deparse(substitute(value))
-  value_string <- paste(value, collapse = ", ") 
+  value_string <- paste(value, collapse = ", ")
   pattern <- paste(
     "Ill-formatted character strings in %s: %s.",
     "%s must equal make.names(%s, unique = FALSE, allow_ = TRUE)"

--- a/R/utils_assert.R
+++ b/R/utils_assert.R
@@ -21,6 +21,21 @@ assert <- function(
   }
 }
 
+assert_chr <- function(value, message = NULL) {
+  assert_chr_vec(value, message = message)
+  assert(value, length(.) == 1L, message = message)
+}
+
+assert_chr_vec <- function(value, message = NULL) {
+  assert(
+    value,
+    is.character(.),
+    !anyNA(.),
+    nzchar(.),
+    message = message
+  )
+}
+
 assert_col <- function(value, data, message = NULL) {
   message <- message %|||% paste(
     paste(value, collapse = ", "),
@@ -33,24 +48,22 @@ assert_col <- function(value, data, message = NULL) {
   )
 }
 
-
-assert_chr_vec <- function(value, message = NULL) {
-  assert(
-    value,
-    is.character(.),
-    !anyNA(.),
-    nzchar(.),
-    message = message
-  )
-}
-
-assert_chr <- function(value, message = NULL) {
-  assert_chr_vec(value, message = message)
-  assert(value, length(.) == 1L, message = message)
-}
-
 assert_lgl <- function(value, message = NULL) {
   assert(value, isTRUE(.) || isFALSE(.), message = message)
+}
+
+assert_machine_names <- function(value, message = NULL) {
+  name <- deparse(substitute(value))
+  value_string <- paste(value, collapse = ", ") 
+  pattern <- paste(
+    "Ill-formatted character strings in %s: %s.",
+    "%s must equal make.names(%s, unique = FALSE, allow_ = TRUE)"
+  )
+  message <- message %|||% sprintf(pattern, name, value_string, name, name)
+  assert(
+    all(value == make.names(value, unique = FALSE, allow_ = TRUE)),
+    message = message
+  )
 }
 
 assert_num <- function(value, message = NULL) {

--- a/R/utils_draws.R
+++ b/R/utils_draws.R
@@ -1,0 +1,27 @@
+brm_sep <- function() {
+  Sys.getenv("BRM_SEP", unset = "|")
+}
+
+gsub_group <- function(names) {
+  out <- strsplit(names, split = "|", fixed = TRUE)
+  as.character(lapply(out, function(x) x[[1L]]))
+}
+
+gsub_time <- function(names) {
+  out <- strsplit(names, split = "|", fixed = TRUE)
+  as.character(lapply(out, function(x) x[[2L]]))
+}
+
+name_marginal <- function(group, time) {
+  sprintf("%s%s%s", group, brm_sep(), time)
+}
+
+names_group <- function(draws) {
+  gsub_group(setdiff(colnames(draws), names_mcmc))
+}
+
+names_time <- function(draws) {
+  gsub_time(setdiff(colnames(draws), names_mcmc))
+}
+
+names_mcmc <- c(".chain", ".draw", ".iteration")

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -26,3 +26,5 @@ AVAL
 tibble
 MCSE
 pre
+preprocess
+preprocessed

--- a/man/brm_data.Rd
+++ b/man/brm_data.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/brm_data.R
 \name{brm_data}
 \alias{brm_data}
-\title{Create an MMRM dataset.}
+\title{Create and preprocess an MMRM dataset.}
 \usage{
 brm_data(
   data,
@@ -27,9 +27,11 @@ is change from baseline (e.g. CHG).}
 \item{base}{Character of length 1, name of the baseline response variable.
 Supply \code{NULL} to ignore or omit.}
 
-\item{group}{Character of length 1, name of the treatment group variable.}
+\item{group}{Character of length 1, name of the treatment group variable.
+Must point to a character vector or factor in the data.}
 
-\item{time}{Character of length 1, name of the discrete time variable.}
+\item{time}{Character of length 1, name of the discrete time variable.
+Must point to a character vector or factor in the data.}
 
 \item{patient}{Character of length 1, name of the patient ID variable.}
 
@@ -42,6 +44,22 @@ the data such as the treatment group and discrete time variables.
 \description{
 Create a dataset to analyze with an MMRM.
 }
+\section{Preprocessing}{
+
+The preprocessing steps in \code{brm_data()} are as follows:
+\itemize{
+\item Perform basic assertions to make sure the data and other arguments
+are properly formatted.
+\item Sanitize the levels of the group and time columns using
+\code{make.names(unique = FALSE, allow_ = TRUE)} to ensure agreement
+between the data and the output of \code{brms}.
+\item For each implicitly missing outcome observation, add explicit row
+with the outcome variable equal to \code{NA_real_}.
+\item Arrange the rows of the data by group, then patient, then discrete time.
+\item Select only the columns of the data relevant to an MMRM analysis.
+}
+}
+
 \section{Separation string}{
 
 Post-processing in \code{\link[=brm_marginal_draws]{brm_marginal_draws()}} names each of the
@@ -54,8 +72,7 @@ this string. To set a custom string yourself, use
 
 \examples{
 set.seed(0)
-sim <- brm_simulate()
-data <- tibble::as_tibble(sim$data)
+data <- brm_simulate()$data
 colnames(data) <- paste0("col_", colnames(data))
 data
 brm_data(

--- a/man/brm_data.Rd
+++ b/man/brm_data.Rd
@@ -28,10 +28,12 @@ is change from baseline (e.g. CHG).}
 Supply \code{NULL} to ignore or omit.}
 
 \item{group}{Character of length 1, name of the treatment group variable.
-Must point to a character vector or factor in the data.}
+Must point to a character vector in the data. Factors are converted
+to characters.}
 
 \item{time}{Character of length 1, name of the discrete time variable.
-Must point to a character vector or factor in the data.}
+Must point to a character vector in the data. Factors are converted
+to characters.}
 
 \item{patient}{Character of length 1, name of the patient ID variable.}
 
@@ -50,6 +52,7 @@ The preprocessing steps in \code{brm_data()} are as follows:
 \itemize{
 \item Perform basic assertions to make sure the data and other arguments
 are properly formatted.
+\item Convert the group and time columns to character vectors.
 \item Sanitize the levels of the group and time columns using
 \code{make.names(unique = FALSE, allow_ = TRUE)} to ensure agreement
 between the data and the output of \code{brms}.

--- a/man/brm_formula.Rd
+++ b/man/brm_formula.Rd
@@ -49,7 +49,7 @@ Build a model formula for an MMRM.
 \examples{
 set.seed(0)
 data <- brm_data(
-  data = tibble::as_tibble(brm_simulate()$data),
+  data = brm_simulate()$data,
   outcome = "response",
   role = "response",
   group = "group",

--- a/man/brm_marginal_data.Rd
+++ b/man/brm_marginal_data.Rd
@@ -39,16 +39,14 @@ Marginal summaries of the data.
 }
 \examples{
 set.seed(0L)
- data <- brm_data(
-   data = tibble::as_tibble(brm_simulate()$data),
-   outcome = "response",
-   role = "response",
-   group = "group",
-   time = "time",
-   patient = "patient"
- )
-data$group <- paste("treatment", data$group)
-data$time <- paste("visit", data$time)
+data <- brm_data(
+  data = brm_simulate()$data,
+  outcome = "response",
+  role = "response",
+  group = "group",
+  time = "time",
+  patient = "patient"
+)
 brm_marginal_data(data = data)
 }
 \seealso{

--- a/man/brm_marginal_draws.Rd
+++ b/man/brm_marginal_draws.Rd
@@ -9,14 +9,20 @@ brm_marginal_draws(model, data, control = "Placebo", baseline = "Baseline")
 \arguments{
 \item{model}{Fitted \code{brms} model object from \code{\link[=brm_model]{brm_model()}}.}
 
-\item{data}{Classed tibble from \code{\link[=brm_data]{brm_data()}}.}
+\item{data}{Classed tibble with preprocessed data from \code{\link[=brm_data]{brm_data()}}.}
 
 \item{control}{Element of the \code{group} column in the data which indicates
-the control group for the purposes of calculating treatment differences.}
+the control group for the purposes of calculating treatment differences.
+Elements in \code{data[[group]]} are already pre-processed by \code{\link[=brms_data]{brms_data()}},
+so \code{control} is automatically sanitized accordingly using
+\code{make.names(control, unique = FALSE, allow_ = TRUE)}.}
 
 \item{baseline}{Element of the \code{time} column in the data
 which indicates the baseline time for the purposes of calculating
-change from baseline.}
+change from baseline.
+Elements in \code{data[[group]]} are already pre-processed by \code{\link[=brms_data]{brms_data()}},
+so \code{control} is automatically sanitized accordingly using
+\code{make.names(control, unique = FALSE, allow_ = TRUE)}.}
 }
 \value{
 A named list of tibbles of MCMC draws of the marginal posterior
@@ -52,15 +58,13 @@ this string. To set a custom string yourself, use
 if (identical(Sys.getenv("BRM_EXAMPLES", unset = ""), "true")) {
 set.seed(0L)
 data <- brm_data(
-  data = tibble::as_tibble(brm_simulate()$data),
+  data = brm_simulate()$data,
   outcome = "response",
   role = "response",
   group = "group",
   time = "time",
   patient = "patient"
 )
-data$group <- paste("treatment", data$group)
-data$time <- paste("visit", data$time)
 formula <- brm_formula(
   data = data,
   effect_base = FALSE,
@@ -82,8 +86,8 @@ tmp <- utils::capture.output(
 brm_marginal_draws(
   model = model,
   data = data,
-  control = "treatment 1",
-  baseline = "visit 1"
+  control = "group.1",
+  baseline = "time.1"
 )
 }
 }

--- a/man/brm_marginal_draws.Rd
+++ b/man/brm_marginal_draws.Rd
@@ -13,14 +13,14 @@ brm_marginal_draws(model, data, control = "Placebo", baseline = "Baseline")
 
 \item{control}{Element of the \code{group} column in the data which indicates
 the control group for the purposes of calculating treatment differences.
-Elements in \code{data[[group]]} are already pre-processed by \code{\link[=brms_data]{brms_data()}},
+Elements in \code{data[[group]]} are already pre-processed by \code{\link[=brm_data]{brm_data()}},
 so \code{control} is automatically sanitized accordingly using
 \code{make.names(control, unique = FALSE, allow_ = TRUE)}.}
 
 \item{baseline}{Element of the \code{time} column in the data
 which indicates the baseline time for the purposes of calculating
 change from baseline.
-Elements in \code{data[[group]]} are already pre-processed by \code{\link[=brms_data]{brms_data()}},
+Elements in \code{data[[group]]} are already pre-processed by \code{\link[=brm_data]{brm_data()}},
 so \code{control} is automatically sanitized accordingly using
 \code{make.names(control, unique = FALSE, allow_ = TRUE)}.}
 }

--- a/man/brm_marginal_draws.Rd
+++ b/man/brm_marginal_draws.Rd
@@ -86,8 +86,8 @@ tmp <- utils::capture.output(
 brm_marginal_draws(
   model = model,
   data = data,
-  control = "group.1",
-  baseline = "time.1"
+  control = "group 1",
+  baseline = "time 1"
 )
 }
 }

--- a/man/brm_marginal_probabilities.Rd
+++ b/man/brm_marginal_probabilities.Rd
@@ -42,15 +42,13 @@ Marginal probabilities on the treatment effect for an MMRM.
 if (identical(Sys.getenv("BRM_EXAMPLES", unset = ""), "true")) {
 set.seed(0L)
 data <- brm_data(
-  data = tibble::as_tibble(brm_simulate()$data),
+  data = brm_simulate()$data,
   outcome = "response",
   role = "response",
   group = "group",
   time = "time",
   patient = "patient"
 )
-data$group <- paste("treatment", data$group)
-data$time <- paste("visit", data$time)
 formula <- brm_formula(
   data = data,
   effect_base = FALSE,
@@ -72,8 +70,8 @@ tmp <- utils::capture.output(
 draws <- brm_marginal_draws(
   model = model,
   data = data,
-  control = "treatment 1",
-  baseline = "visit 1"
+  control = "group 1",
+  baseline = "time 1"
 )
 brm_marginal_probabilities(draws, direction = "greater", threshold = 0)
 }

--- a/man/brm_marginal_summaries.Rd
+++ b/man/brm_marginal_summaries.Rd
@@ -47,15 +47,13 @@ Summary statistics of the marginal posterior of an MMRM.
 if (identical(Sys.getenv("BRM_EXAMPLES", unset = ""), "true")) {
 set.seed(0L)
 data <- brm_data(
-  data = tibble::as_tibble(brm_simulate()$data),
+  data = brm_simulate()$data,
   outcome = "response",
   role = "response",
   group = "group",
   time = "time",
   patient = "patient"
 )
-data$group <- paste("treatment", data$group)
-data$time <- paste("visit", data$time)
 formula <- brm_formula(
   data = data,
   effect_base = FALSE,
@@ -77,8 +75,8 @@ tmp <- utils::capture.output(
 draws <- brm_marginal_draws(
   model = model,
   data = data,
-  control = "treatment 1",
-  baseline = "visit 1"
+  control = "group 1",
+  baseline = "time 1"
 )
 suppressWarnings(brm_marginal_summaries(draws))
 }

--- a/man/brm_model.Rd
+++ b/man/brm_model.Rd
@@ -36,7 +36,7 @@ Fit a basic MMRM model using \code{brms}.
 if (identical(Sys.getenv("BRM_EXAMPLES", unset = ""), "true")) {
 set.seed(0L)
 data <- brm_data(
-  data = tibble::as_tibble(brm_simulate()$data),
+  data = brm_simulate()$data,
   outcome = "response",
   role = "response",
   group = "group",

--- a/man/brm_plot_compare.Rd
+++ b/man/brm_plot_compare.Rd
@@ -25,15 +25,13 @@ Visually compare the marginals of models and datasets.
 if (identical(Sys.getenv("BRM_EXAMPLES", unset = ""), "true")) {
 set.seed(0L)
 data <- brm_data(
-  data = tibble::as_tibble(brm_simulate()$data),
+  data = brm_simulate()$data,
   outcome = "response",
   role = "response",
   group = "group",
   time = "time",
   patient = "patient"
 )
-data$group <- paste("treatment", data$group)
-data$time <- paste("visit", data$time)
 formula <- brm_formula(
   data = data,
   effect_base = FALSE,
@@ -55,8 +53,8 @@ tmp <- utils::capture.output(
 draws <- brm_marginal_draws(
   model = model,
   data = data,
-  control = "treatment 1",
-  baseline = "visit 1"
+  control = "group 1",
+  baseline = "time 1"
 )
 suppressWarnings(summaries_draws <- brm_marginal_summaries(draws))
 summaries_data <- brm_marginal_data(data)

--- a/man/brm_plot_draws.Rd
+++ b/man/brm_plot_draws.Rd
@@ -20,15 +20,13 @@ Visualize posterior draws of marginals.
 if (identical(Sys.getenv("BRM_EXAMPLES", unset = ""), "true")) {
 set.seed(0L)
 data <- brm_data(
-  data = tibble::as_tibble(brm_simulate()$data),
+  data = brm_simulate()$data,
   outcome = "response",
   role = "response",
   group = "group",
   time = "time",
   patient = "patient"
 )
-data$group <- paste("treatment", data$group)
-data$time <- paste("visit", data$time)
 formula <- brm_formula(
   data = data,
   effect_base = FALSE,
@@ -50,8 +48,8 @@ tmp <- utils::capture.output(
 draws <- brm_marginal_draws(
   model = model,
   data = data,
-  control = "treatment 1",
-  baseline = "visit 1"
+  control = "group 1",
+  baseline = "time 1"
 )
 brm_plot_draws(draws = draws$change)
 }

--- a/tests/testthat/test-brm_data.R
+++ b/tests/testthat/test-brm_data.R
@@ -53,17 +53,23 @@ test_that("brm_data() good", {
   )
   expect_equal(out$col_patient, out$col_factor2)
   expect_equal(out$col_patient, out$col_factor3)
-  expect_equal(attr(out, "outcome"), "col_response")
-  expect_equal(attr(out, "role"), "response")
-  expect_equal(attr(out, "group"), "col_group")
-  expect_equal(attr(out, "time"), "col_time")
-  expect_equal(attr(out, "patient"), "col_patient")
-  expect_equal(attr(out, "covariates"), c("col_factor2", "col_factor3"))
+  expect_equal(attr(out, "brm_outcome"), "col_response")
+  expect_equal(attr(out, "brm_role"), "response")
+  expect_equal(attr(out, "brm_group"), "col_group")
+  expect_equal(attr(out, "brm_time"), "col_time")
+  expect_equal(attr(out, "brm_patient"), "col_patient")
+  expect_equal(attr(out, "brm_covariates"), c("col_factor2", "col_factor3"))
   expect_equal(
-    sort(attr(out, "levels_group")), c("group.1", "group.2")
+    sort(attr(out, "brm_levels_group")), c("group.1", "group.2")
   )
   expect_equal(
-    sort(attr(out, "levels_time")), paste0("time.", seq_len(4L))
+    sort(attr(out, "brm_levels_time")), paste0("time.", seq_len(4L))
+  )
+  expect_equal(
+    sort(attr(out, "brm_labels_group")), c("group 1", "group 2")
+  )
+  expect_equal(
+    sort(attr(out, "brm_labels_time")), paste("time", seq_len(4L))
   )
 })
 

--- a/tests/testthat/test-brm_data.R
+++ b/tests/testthat/test-brm_data.R
@@ -2,6 +2,7 @@ test_that("brm_data() good", {
   set.seed(0)
   sim <- brm_simulate()
   data <- tibble::as_tibble(sim$data)
+  data$group <- as.factor(data$group)
   data$factor1 <- data$patient
   data$factor2 <- data$patient
   data$factor3 <- data$patient
@@ -42,10 +43,7 @@ test_that("brm_data() good", {
   )
   expect_equal(
     out$col_time,
-    ordered(
-      rep(paste0("time.", seq_len(4L)), times = 200L),
-      levels = paste0("time.", seq_len(4L))
-    )
+    rep(paste0("time.", seq_len(4L)), times = 200L)
   )
   expect_equal(
     sort(out$col_response[- c(2L, 3L)]),

--- a/tests/testthat/test-brm_marginal_data.R
+++ b/tests/testthat/test-brm_marginal_data.R
@@ -8,8 +8,6 @@ test_that("brm_marginal_data()", {
     time = "time",
     patient = "patient"
   )
-  data$group <- paste("treatment", data$group)
-  data$time <- paste("visit", data$time)
   data$response[1L] <- NA_real_
   out <- brm_marginal_data(
     data = data,

--- a/tests/testthat/test-brm_marginal_draws.R
+++ b/tests/testthat/test-brm_marginal_draws.R
@@ -2,15 +2,13 @@ test_that("brm_marginal_draws() on response", {
   skip_on_cran()
   set.seed(0L)
   data <- brm_data(
-    data = tibble::as_tibble(brm_simulate()$data),
+    data = brm_simulate()$data,
     outcome = "response",
     role = "response",
     group = "group",
     time = "time",
     patient = "patient"
   )
-  data$group <- paste("treatment", data$group)
-  data$time <- paste("visit", data$time)
   formula <- brm_formula(
     data = data,
     effect_base = FALSE,
@@ -33,8 +31,8 @@ test_that("brm_marginal_draws() on response", {
   out <- brm_marginal_draws(
     model = model,
     data = data,
-    control = "treatment 1",
-    baseline = "visit 1"
+    control = "group.1",
+    baseline = "time.1"
   )
   expect_equal(emmeans::get_emm_option("sep"), old_sep)
   fields <- c("response", "change", "difference")
@@ -56,21 +54,21 @@ test_that("brm_marginal_draws() on response", {
     sort(colnames(out$response)),
     sort(c(columns, names_mcmc))
   )
-  columns_df <- columns_df[columns_df$time != "visit 1", ]
+  columns_df <- columns_df[columns_df$time != "time.1", ]
   columns <- paste(columns_df$group, columns_df$time, sep = brm_sep())
   expect_equal(
     sort(colnames(out$change)),
     sort(c(columns, names_mcmc))
   )
-  columns_df <- columns_df[columns_df$group != "treatment 1", ]
+  columns_df <- columns_df[columns_df$group != "group.1", ]
   columns <- paste(columns_df$group, columns_df$time, sep = brm_sep())
   expect_equal(
     sort(colnames(out$difference)),
     sort(c(columns, names_mcmc))
   )
-  for (group in setdiff(unique(data$group), "treatment 1")) {
-    for (time in setdiff(unique(data$time), "visit 1")) {
-      name1 <- paste("treatment 1", time, sep = brm_sep())
+  for (group in setdiff(unique(data$group), "group.1")) {
+    for (time in setdiff(unique(data$time), "time.1")) {
+      name1 <- paste("group.1", time, sep = brm_sep())
       name2 <- paste(group, time, sep = brm_sep())
       expect_equal(
         out$difference[[name2]],
@@ -79,8 +77,8 @@ test_that("brm_marginal_draws() on response", {
     }
   }
   for (group in unique(data$group)) {
-    for (time in setdiff(unique(data$time), "visit 1")) {
-      name1 <- paste(group, "visit 1", sep = brm_sep())
+    for (time in setdiff(unique(data$time), "time.1")) {
+      name1 <- paste(group, "time.1", sep = brm_sep())
       name2 <- paste(group, time, sep = brm_sep())
       expect_equal(
         out$change[[name2]],
@@ -101,8 +99,6 @@ test_that("brm_marginal_draws() on change", {
     time = "time",
     patient = "patient"
   )
-  data$group <- paste("treatment", data$group)
-  data$time <- paste("visit", data$time)
   formula <- brm_formula(
     data = data,
     effect_base = FALSE,
@@ -124,8 +120,8 @@ test_that("brm_marginal_draws() on change", {
   out <- brm_marginal_draws(
     model = model,
     data = data,
-    control = "treatment 1",
-    baseline = "visit 1"
+    control = "group.1",
+    baseline = "time.1"
   )
   fields <- c("response", "difference")
   columns_df <- expand.grid(
@@ -146,15 +142,15 @@ test_that("brm_marginal_draws() on change", {
     sort(colnames(out$response)),
     sort(c(columns, names_mcmc))
   )
-  columns_df <- columns_df[columns_df$group != "treatment 1", ]
+  columns_df <- columns_df[columns_df$group != "group.1", ]
   columns <- paste(columns_df$group, columns_df$time, sep = brm_sep())
   expect_equal(
     sort(colnames(out$difference)),
     sort(c(columns, names_mcmc))
   )
-  for (group in setdiff(unique(data$group), "treatment 1")) {
+  for (group in setdiff(unique(data$group), "group.1")) {
     for (time in unique(data$time)) {
-      name1 <- paste("treatment 1", time, sep = brm_sep())
+      name1 <- paste("group.1", time, sep = brm_sep())
       name2 <- paste(group, time, sep = brm_sep())
       expect_equal(
         out$difference[[name2]],

--- a/tests/testthat/test-brm_marginal_probabilities.R
+++ b/tests/testthat/test-brm_marginal_probabilities.R
@@ -9,8 +9,6 @@ test_that("brm_marginal_probabilities() on response", {
     time = "time",
     patient = "patient"
   )
-  data$group <- paste("treatment", data$group)
-  data$time <- paste("visit", data$time)
   formula <- brm_formula(
     data = data,
     effect_base = FALSE,
@@ -32,8 +30,8 @@ test_that("brm_marginal_probabilities() on response", {
   draws <- brm_marginal_draws(
     model = model,
     data = data,
-    control = "treatment 1",
-    baseline = "visit 1"
+    control = "group.1",
+    baseline = "time.1"
   )
   x <- brm_marginal_probabilities(
     draws,
@@ -44,12 +42,12 @@ test_that("brm_marginal_probabilities() on response", {
     sort(colnames(x)),
     sort(c("group", "time", "direction", "threshold", "value"))
   )
-  expect_equal(x$group, rep("treatment 2", 3))
-  expect_equal(x$time, paste("visit", seq(2, 4)))
+  expect_equal(x$group, rep("group.2", 3))
+  expect_equal(x$time, paste0("time.", seq(2, 4)))
   expect_equal(x$direction, rep("greater", 3))
   expect_equal(x$threshold, rep(0, 3))
   column <- function(group, time) {
-    sprintf("treatment %s%svisit %s", group, brm_sep(), time)
+    sprintf("group.%s%stime.%s", group, brm_sep(), time)
   }
   expect_equal(
     x$value[1L],
@@ -76,8 +74,6 @@ test_that("brm_marginal_probabilities() on change and multiple probs", {
     time = "time",
     patient = "patient"
   )
-  data$group <- paste("treatment", data$group)
-  data$time <- paste("visit", data$time)
   formula <- brm_formula(
     data = data,
     effect_base = FALSE,
@@ -99,8 +95,8 @@ test_that("brm_marginal_probabilities() on change and multiple probs", {
   draws <- brm_marginal_draws(
     model = model,
     data = data,
-    control = "treatment 1",
-    baseline = "visit 1"
+    control = "group.1",
+    baseline = "time.1"
   )
   for (index in seq_along(draws$difference)) {
     draws$difference[[index]] <- seq_len(nrow(draws$difference))
@@ -114,8 +110,8 @@ test_that("brm_marginal_probabilities() on change and multiple probs", {
     sort(colnames(x)),
     sort(c("group", "time", "direction", "threshold", "value"))
   )
-  expect_equal(x$group, rep("treatment 2", 8))
-  expect_equal(x$time, rep(paste("visit", seq(1, 4)), times = 2))
+  expect_equal(x$group, rep("group.2", 8))
+  expect_equal(x$time, rep(paste0("time.", seq(1, 4)), times = 2))
   expect_equal(x$direction, rep(c("greater", "less"), each = 4))
   expect_equal(x$threshold, c(rep(30, 4), rep(15, 4)))
   expect_equal(x$value, rep(c(0.4, 0.28), each = 4L))

--- a/tests/testthat/test-brm_marginal_summaries.R
+++ b/tests/testthat/test-brm_marginal_summaries.R
@@ -9,8 +9,6 @@ test_that("brm_marginal_summaries() on response", {
     time = "time",
     patient = "patient"
   )
-  data$group <- paste("treatment", data$group)
-  data$time <- paste("visit", data$time)
   formula <- brm_formula(
     data = data,
     effect_base = FALSE,
@@ -32,8 +30,8 @@ test_that("brm_marginal_summaries() on response", {
   draws <- brm_marginal_draws(
     model = model,
     data = data,
-    control = "treatment 1",
-    baseline = "visit 1"
+    control = "group.1",
+    baseline = "time.1"
   )
   suppressWarnings(
     x <- brm_marginal_summaries(
@@ -53,7 +51,7 @@ test_that("brm_marginal_summaries() on response", {
     groups <- unique(data$group)
     times <- unique(data$time)
     if (marginal %in% c("change", "difference")) {
-      times <- setdiff(times, "visit 1")
+      times <- setdiff(times, "time.1")
     }
     if (identical(marginal, "difference")) {
       groups <- setdiff(groups, "difference")
@@ -131,8 +129,6 @@ test_that("brm_marginal_summaries() on change", {
     time = "time",
     patient = "patient"
   )
-  data$group <- paste("treatment", data$group)
-  data$time <- paste("visit", data$time)
   formula <- brm_formula(
     data = data,
     effect_base = FALSE,
@@ -154,8 +150,8 @@ test_that("brm_marginal_summaries() on change", {
   draws <- brm_marginal_draws(
     model = model,
     data = data,
-    control = "treatment 1",
-    baseline = "visit 1"
+    control = "group.1",
+    baseline = "time.1"
   )
   suppressWarnings(
     x <- brm_marginal_summaries(

--- a/tests/testthat/test-brm_plot_compare.R
+++ b/tests/testthat/test-brm_plot_compare.R
@@ -9,8 +9,6 @@ test_that("brm_plot_compare()", {
     time = "time",
     patient = "patient"
   )
-  data$group <- paste("treatment", data$group)
-  data$time <- paste("visit", data$time)
   formula <- brm_formula(
     data = data,
     effect_base = FALSE,
@@ -32,8 +30,8 @@ test_that("brm_plot_compare()", {
   draws <- brm_marginal_draws(
     model = model,
     data = data,
-    control = "treatment 1",
-    baseline = "visit 1"
+    control = "group.1",
+    baseline = "time.1"
   )
   suppressWarnings(summaries_draws <- brm_marginal_summaries(draws))
   summaries_data <- brm_marginal_data(data)

--- a/tests/testthat/test-brm_plot_draws.R
+++ b/tests/testthat/test-brm_plot_draws.R
@@ -9,8 +9,6 @@ test_that("brm_plot_draws()", {
     time = "time",
     patient = "patient"
   )
-  data$group <- paste("treatment", data$group)
-  data$time <- paste("visit", data$time)
   formula <- brm_formula(
     data = data,
     effect_base = FALSE,
@@ -32,8 +30,8 @@ test_that("brm_plot_draws()", {
   draws <- brm_marginal_draws(
     model = model,
     data = data,
-    control = "treatment 1",
-    baseline = "visit 1"
+    control = "group.1",
+    baseline = "time.1"
   )
   out <- brm_plot_draws(draws = draws$change)
   expect_s3_class(out, "ggplot")

--- a/tests/testthat/test-brm_simulate.R
+++ b/tests/testthat/test-brm_simulate.R
@@ -12,9 +12,10 @@ test_that("brm_simulate() data", {
   expect_equal(dim(data), c(12L, 4L))
   expect_true(is.numeric(data$response))
   expect_false(anyNA(data$response))
-  expect_equal(as.integer(data$group), rep(seq_len(2L), each = 6L))
-  expect_equal(as.integer(data$patient), rep(seq_len(4L), each = 3L))
-  expect_equal(as.integer(data$time), rep(seq_len(3L), times = 4L))
+  expect_equal(data$group, paste("group", rep(seq_len(2L), each = 6L)))
+  expect_equal(data$patient, paste("patient", rep(seq_len(4L), each = 3L)))
+  levels_time <- paste("time", seq_len(3L))
+  expect_equal(data$time, rep(levels_time, times = 4L))
 })
 
 test_that("brm_simulate() model_matrix", {
@@ -29,10 +30,18 @@ test_that("brm_simulate() model_matrix", {
   )
   matrix <- out$model_matrix
   expect_equal(dim(matrix), c(12L, 4L))
-  expect_equal(as.integer(matrix[, "group1"]), rep(c(1L, 0L), each = 6L))
-  expect_equal(as.integer(matrix[, "group2"]), rep(c(0L, 1L), each = 6L))
-  expect_equal(as.integer(matrix[, "time2"]), as.integer(out$data$time == 2L))
-  expect_equal(as.integer(matrix[, "time3"]), as.integer(out$data$time == 3L))
+  colnames(matrix) <- gsub("^group", "", colnames(matrix))
+  colnames(matrix) <- gsub("^time", "", colnames(matrix))
+  expect_equal(as.integer(matrix[, "group 1"]), rep(c(1L, 0L), each = 6L))
+  expect_equal(as.integer(matrix[, "group 2"]), rep(c(0L, 1L), each = 6L))
+  expect_equal(
+    as.integer(matrix[, "time 2"]),
+    as.integer(out$data$time == "time 2")
+  )
+  expect_equal(
+    as.integer(matrix[, "time 3"]),
+    as.integer(out$data$time == "time 3")
+  )
 })
 
 test_that("brm_simulate() parameters", {

--- a/tests/testthat/test-utils_assert.R
+++ b/tests/testthat/test-utils_assert.R
@@ -22,6 +22,12 @@ test_that("assert_chr()", {
   expect_error(assert_chr(c(2L, 3L)), class = "brm_error")
 })
 
+test_that("assert_col()", {
+  data <- data.frame(x = 1)
+  expect_silent(assert_col("x", data))
+  expect_error(assert_col("y", data), class = "brm_error")
+})
+
 test_that("assert_lgl()", {
   expect_silent(assert_lgl(TRUE))
   expect_silent(assert_lgl(FALSE))
@@ -29,6 +35,11 @@ test_that("assert_lgl()", {
   expect_error(assert_lgl(logical(0L)), class = "brm_error")
   expect_error(assert_lgl(123.321), class = "brm_error")
   expect_error(assert_lgl(c(1L, 2L)), class = "brm_error")
+})
+
+test_that("assert_machine_names()", {
+  expect_silent(assert_machine_names("x"))
+  expect_error(assert_machine_names("_x"), class = "brm_error")
 })
 
 test_that("assert_num()", {

--- a/vignettes/usage.Rmd
+++ b/vignettes/usage.Rmd
@@ -32,12 +32,8 @@ raw_data <- brm_simulate(
   n_group = 3,
   n_patient = 100,
   n_time = 4
-)$data %>%
-  mutate(
-    group = paste("group", group),
-    patient = paste("patient", patient),
-    time = paste("time", time)
-  )
+)$data
+
 raw_data
 ```
 
@@ -61,6 +57,8 @@ roles <- attributes(data)
 roles$row.names <- NULL
 str(roles)
 ```
+
+Above, the levels of the `group` and `time` columns are automatically cleaned with `make.names()` to ensure alignment between the data and `brms` output. Whenever `brms.mmrm` calls `make.names()`, it always sets `unique = FALSE` and `allow_ = TRUE`.
 
 ## Formula
 
@@ -120,8 +118,8 @@ Regardless of the choice of fixed effects formula, `brms.mmrm` performs inferenc
 draws <- brm_marginal_draws(
   model = model,
   data = data,
-  control = "group 1",
-  baseline = "time 1"
+  control = "group 1", # automatically cleaned with make.names()
+  baseline = "time 1" # also cleaned with make.names()
 )
 
 draws


### PR DESCRIPTION
`brms` automatically sanitizes the levels of factors for its parameter names, which unfortunately means alignment between data and MCMC output is not automatic. This PR applies `make.names(unique = FALSE, allow_ = TRUE)` during `brm_data()` so alignment is assured. And the S3 data object now stores both the  original levels and the new levels of treatment group and discrete time in special attributes.

Fixes #45.