### PR TITLE
Effect size

### DIFF
--- a/R/brm_marginal_summaries.R
+++ b/R/brm_marginal_summaries.R
@@ -83,10 +83,12 @@ brm_marginal_summaries <- function(
     NULL
   )
   table_difference <- summarize_marginals(draws$difference, level)
+  table_effect <- summarize_marginals(draws$effect, level)
   out <- dplyr::bind_rows(
     response = table_response,
     change = table_change,
     difference = table_difference,
+    effect = table_effect,
     .id = "marginal"
   )
   columns <- c("marginal", "statistic", "group", "time", "value", "mcse")

--- a/tests/testthat/test-brm_marginal_draws.R
+++ b/tests/testthat/test-brm_marginal_draws.R
@@ -35,7 +35,7 @@ test_that("brm_marginal_draws() on response", {
     baseline = "time.1"
   )
   expect_equal(emmeans::get_emm_option("sep"), old_sep)
-  fields <- c("response", "change", "difference")
+  fields <- c("response", "change", "difference", "effect")
   columns_df <- expand.grid(
     group = sort(unique(data$group)),
     time = sort(unique(data$time)),
@@ -66,6 +66,11 @@ test_that("brm_marginal_draws() on response", {
     sort(colnames(out$difference)),
     sort(c(columns, names_mcmc))
   )
+  draws <- tibble::as_tibble(posterior::as_draws_df(model))
+  draws <- draws[, grep("^b_sigma_", colnames(draws), value = TRUE)]
+  colnames(draws) <- gsub("^b_sigma_", "", colnames(draws))
+  colnames(draws) <- gsub(paste0("^time"), "", x = colnames(draws))
+  sigma <- exp(draws)
   for (group in setdiff(unique(data$group), "group.1")) {
     for (time in setdiff(unique(data$time), "time.1")) {
       name1 <- paste("group.1", time, sep = brm_sep())
@@ -73,6 +78,10 @@ test_that("brm_marginal_draws() on response", {
       expect_equal(
         out$difference[[name2]],
         out$change[[name2]] - out$change[[name1]]
+      )
+      expect_equal(
+        out$effect[[name2]],
+        out$difference[[name2]] / sigma[[time]]
       )
     }
   }

--- a/tests/testthat/test-brm_marginal_draws.R
+++ b/tests/testthat/test-brm_marginal_draws.R
@@ -132,7 +132,7 @@ test_that("brm_marginal_draws() on change", {
     control = "group.1",
     baseline = "time.1"
   )
-  fields <- c("response", "difference")
+  fields <- c("response", "difference", "effect")
   columns_df <- expand.grid(
     group = sort(unique(data$group)),
     time = sort(unique(data$time)),

--- a/tests/testthat/test-brm_marginal_summaries.R
+++ b/tests/testthat/test-brm_marginal_summaries.R
@@ -45,9 +45,9 @@ test_that("brm_marginal_summaries() on response", {
   )
   expect_equal(
     sort(unique(x$marginal)),
-    sort(c("response", "change", "difference"))
+    sort(c("response", "change", "difference", "effect"))
   )
-  for (marginal in c("response", "change", "difference")) {
+  for (marginal in c("response", "change", "difference", "effect")) {
     groups <- unique(data$group)
     times <- unique(data$time)
     if (marginal %in% c("change", "difference")) {
@@ -165,9 +165,9 @@ test_that("brm_marginal_summaries() on change", {
   )
   expect_equal(
     sort(unique(x$marginal)),
-    sort(c("response", "difference"))
+    sort(c("response", "difference", "effect"))
   )
-  for (marginal in c("response", "difference")) {
+  for (marginal in c("response", "difference", "effect")) {
     groups <- unique(data$group)
     times <- unique(data$time)
     if (identical(marginal, "difference")) {

--- a/vignettes/usage.Rmd
+++ b/vignettes/usage.Rmd
@@ -112,7 +112,14 @@ model
 
 ## Marginals
 
-Regardless of the choice of fixed effects formula, `brms.mmrm` performs inference on the marginal distributions at each treatment group and time point: the mean response, mean change from baseline, and mean treatment effect in terms of change from baseline. To derive posterior draws of these marginals, use the `brm_marginal_draws()` function.
+Regardless of the choice of fixed effects formula, `brms.mmrm` performs inference on the marginal distributions at each treatment group and time point of the mean of the following quantities:
+
+1. Response.
+2. Change from baseline, if you set `role` to `"change"` in `brm_data()`.
+3. Treatment difference, in terms of change from baseline.
+4. Effect size: treatment difference divided by the residual standard deviation.
+
+To derive posterior draws of these marginals, use the `brm_marginal_draws()` function.
 
 ```{r, paged.print = FALSE}
 draws <- brm_marginal_draws(


### PR DESCRIPTION
This PR calculates the marginal posteriors of treatment difference / std dev. Modifies functions `brm_marginal_draws()` and `brm_marginal_summaries()`, as well as the usage vignette.